### PR TITLE
Update config_agent.go

### DIFF
--- a/config/config_agent.go
+++ b/config/config_agent.go
@@ -31,8 +31,8 @@ type ConfigAgent struct {
 	t      utils.Timer
 }
 
-func NewConfigAgent(b NewConfig) ConfigAgent {
-	return ConfigAgent{b: b, t: utils.NewTimer()}
+func NewConfigAgent(b NewConfig) *ConfigAgent {
+	return &ConfigAgent{b: b, t: utils.NewTimer()}
 }
 
 func (ca *ConfigAgent) load(path string) error {


### PR DESCRIPTION
community-robot-lib的config/config_agent.go：
func NewConfigAgent(b NewConfig) ConfigAgent {
return ConfigAgent{b: b, t: utils.NewTimer()}
在这个ConfigAgent结构体中，sync.RWMutex是通过值嵌入的。当你创建ConfigAgent的实例并返回时，它是通过值返回的，这意味着调用者得到的是ConfigAgent的一个拷贝。
改为：
func NewConfigAgent(b NewConfig) *ConfigAgent {
return &ConfigAgent{b: b, t: utils.NewTimer()}
}